### PR TITLE
Update zpl logic

### DIFF
--- a/js/generateTubeLabels.js
+++ b/js/generateTubeLabels.js
@@ -30,7 +30,7 @@ $(document).ready(function () {
                 },
             )
             .prop('disabled', true),
-            
+
     );
 
     const $genLabelButton = $(`#${GEN_LABEL_BUTTON_ID}`);
@@ -47,14 +47,14 @@ $(document).ready(function () {
     // Attach input listeners for ptid and visit num field
     $ptidInputField.on('input', () => handleOnFieldChange());
     $visitNumInputField.on('input', () => handleOnFieldChange());
-    
+
     // Call function to enable/disable the button on load
     handleOnFieldChange();
 
     // Attach click listener to the "Generate biospecimens label"  button
     $genLabelButton.on('click', () => {
         // Make an ajax call to generate labels
-        TLG.ajax("generateTubeLabels", {'ptid': $ptidInputField.val(), 'visit_num': $visitNumInputField.val()}).then(r => {
+        TLG.ajax("generateTubeLabels", { 'ptid': $ptidInputField.val(), 'visit_num': $visitNumInputField.val() }).then(r => {
             labels = JSON.parse(r);
             zplLabels = [];
             labels.forEach((item, index) => {
@@ -62,13 +62,20 @@ $(document).ready(function () {
                 zplLabels.push(genrateZplLabel(ptid, type, barcode_str));
             });
             zplSheet = zplLabels.reduce((acc, curr) => (acc += curr), "");
-            downloadMultiLabelPdf(zplSheet);
+            // code from https://gist.github.com/Lakerfield/1b77b03789525c9d0f13ddfeedee2efa
+            var printWindow = window.open();
+            printWindow.document.open('text/plain')
+            printWindow.document.write(zplSheet);
+            printWindow.document.close();
+            printWindow.focus();
+            printWindow.print();
+            printWindow.close();
         });
     });
 });
 
 const genrateZplLabel = (ptid, type, barcode) => {
-    zplLabel = `^XA^PW380^LL192^FO24,48^A0N,30,24^FD${barcode}^FS^FO30,78^BQN,2,2,Q,7^FDQA,${barcode}^FS^FO96,108^A0N,30,24^FD${ptid} ${type}^FS^FO300,60^BQN,2,2,Q,7^FDQA,${barcode}^FS^XZ`;
+    zplLabel = `^XA^PW382^LL190^FO26,30^A0N,30,24^FD${barcode}^FS^FO32,60^BQN,2,2,Q,7^FDQA,${barcode}^FS^FO98,90^A0N,30,24^${ptid} ${type}^FS^FO315,45^BQN,2,2,Q,7^FDQA,${barcode}^FS^XZ`;
     return zplLabel;
 };
 


### PR DESCRIPTION
The code has been updated to attempt to print the raw zpl via the native browser print menu. If the zpl needs to be updated that can be done here:
> https://github.com/ctsit/tube_label_generator/blob/b9e9588baedfe6d2e36e87ce397697eadf241000/js/generateTubeLabels.js#L78

and the zpl can be iterated using: https://github.com/ctsit/zpl_generator. Unfortunately I'm not able to test if printing a label this way works. Zebra does not have any drivers for Mac, and I wasn't able to install the drivers on Windows VM either. To test this we likely need a native windows PC. If printing the raw zpl using the native browser print menu doesn't work, then another option is to:
- request access to Zebra's [browser print](https://www.zebra.com/us/en/support-downloads/software/printer-software/browser-print.html) Mac client/javascript library
- include the javascript library as part of the external module following the same convention as the pdf lib library:
  - > https://github.com/ctsit/tube_label_generator/blob/b9e9588baedfe6d2e36e87ce397697eadf241000/ExternalModule.php#L104
-  print using the Zebra Browser print javascript library

Zebra Browser Print (ZBP) is a desktop application that allows the web browser to find label printers on the local network. More information on my research can be found in this [google doc](https://docs.google.com/document/d/1GQEEjWT3GJ1qgpP_KvRkIgpKhnePzI_8XZmrgQOL52U/edit#heading=h.3krs1xf2q5v6).

